### PR TITLE
Use the correct connection object

### DIFF
--- a/src/liquidator.ts
+++ b/src/liquidator.ts
@@ -78,7 +78,7 @@ async function runLiquidator() {
 
   console.log(`Port liquidator launched on cluster=${clusterUrl}`);
 
-  const reserveContext = await Port.forMainNet({}).getReserveContext();
+  const reserveContext = await Port.forMainNet({connection: connection}).getReserveContext();
 
   const wallets = await prepareTokenAccounts(provider, reserveContext);
 


### PR DESCRIPTION
Use the correct connection object to connect to the right clusterUrl for the liquidations.

Currently liquidator will connect to https://api.mainnet-beta.solana.com regardless of which CLUSTER_URL is specified.